### PR TITLE
Update DenseMap::updateLocalPointCloud and DenseMapper::processInput methods

### DIFF
--- a/norlab_dense_mapper/DenseMap.cpp
+++ b/norlab_dense_mapper/DenseMap.cpp
@@ -856,11 +856,10 @@ void norlab_dense_mapper::DenseMap::updateLocalPointCloud(PM::DataPoints input,
             retrievePointsFurtherThanMinDistNewPoint(input, localPointCloud, pose);
         localPointCloud.concatenate(inputPointsToKeep);
     }
-
-    PM::DataPoints localPointCloudInSensorFrame =
-        transformation->compute(localPointCloud, pose.inverse());
-    postFilters.apply(localPointCloudInSensorFrame);
-    localPointCloud = transformation->compute(localPointCloudInSensorFrame, pose);
+    
+    transformation->inPlaceCompute(pose.inverse(), localPointCloud);
+    postFilters.apply(localPointCloud);
+    transformation->inPlaceCompute(pose, localPointCloud);
     localPointCloudEmpty.store(localPointCloud.getNbPoints() == 0);
     newLocalPointCloudAvailable = true;
     localPointCloudLock.unlock();

--- a/norlab_dense_mapper/DenseMapper.cpp
+++ b/norlab_dense_mapper/DenseMapper.cpp
@@ -129,7 +129,8 @@ void norlab_dense_mapper::DenseMapper::processInput(
         sensorFilters.apply(filteredInputInSensorFrame);
     }
 
-    // Compute the transformation between the sensor frame (lidar or depth camera) and the robot frame (base_link)
+    // Compute the transformation between the sensor frame (lidar or depth camera) and the robot
+    // frame (base_link)
     PM::DataPoints inputInRobotFrame =
         transformation->compute(filteredInputInSensorFrame, sensorToRobot);
 

--- a/norlab_dense_mapper/DenseMapper.cpp
+++ b/norlab_dense_mapper/DenseMapper.cpp
@@ -160,15 +160,14 @@ void norlab_dense_mapper::DenseMapper::processInput(
     if (denseMap.isLocalPointCloudEmpty())
     {
         // denseMap.updatePose(sensorToRobot);
-        updateMap(inputInMapFrame, sensorToMap, timeStamp);
+        updateMap(inputInMapFrame, robotStabilizedToMap, timeStamp);
     }
     else
     {
         // denseMap.updatePose(sensorToRobot);
-
-        if (shouldUpdateMap(timeStamp, sensorToMap))
+        if (shouldUpdateMap(timeStamp, robotStabilizedToMap))
         {
-            updateMap(inputInMapFrame, sensorToMap, timeStamp);
+            updateMap(inputInMapFrame, robotStabilizedToMap, timeStamp);
         }
     }
 }

--- a/norlab_dense_mapper/DenseMapper.h
+++ b/norlab_dense_mapper/DenseMapper.h
@@ -3,7 +3,6 @@
 
 #include <pointmatcher/PointMatcher.h>
 #include "DenseMap.h"
-#include "Trajectory.h"
 #include <future>
 #include <mutex>
 


### PR DESCRIPTION
In `DenseMapper::processInput`: changing the transformation from `sensorToMap` to `robotStabilizedToMap` gives better results when applying the map's post filters.

In `DenseMap::updateLocalPointCloud`, the `localPointCloud` transformation is now computed in place to reflect that the inverse of the `pose` is not necessarily in the sensor frame.